### PR TITLE
Add console tranport in prod

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aida-server",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Server to control all requests directed to my IoT devices in home",
   "main": "./dist/server.js",
   "author": "Nikhil Warke",

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -38,15 +38,15 @@ const logFormat = winston.format.combine(
 export const logger = winston.createLogger({
   level: 'info',
   levels,
-  transports: [new winston.transports.File({ filename: 'app.log' })],
+  transports: [
+    new winston.transports.File({ filename: 'app.log' }),
+    new winston.transports.Console({
+      format: winston.format.combine(winston.format.colorize(), logFormat)
+    })
+  ],
   format: logFormat
 });
 
 if (process.env.NODE_ENV !== 'production') {
-  logger.add(
-    new winston.transports.Console({
-      format: winston.format.combine(winston.format.colorize(), logFormat)
-    })
-  );
   logger.level = 'verbose';
 }


### PR DESCRIPTION
Heroku uses console logs to collect logs from app so enable it
production environment.

Bump to v2.0.1